### PR TITLE
Add support for deep objects in isActionDispatched.

### DIFF
--- a/src/utils/DispatchMock.js
+++ b/src/utils/DispatchMock.js
@@ -1,4 +1,6 @@
 /* eslint-disable import/prefer-default-export */
+import equals from './equals';
+
 export const createMockDispatch = () => {
   const actions = [];
   return {
@@ -31,13 +33,7 @@ export const createMockDispatch = () => {
     isActionDispatched(action) {
       for (let i = 0; i < actions.length; i += 1) {
         if (actions[i].type === action.type) {
-          let equalActions = true;
-          Object.keys(action).forEach((key) => {
-            if (actions[i][key] !== action[key]) {
-              equalActions = false;
-            }
-          });
-          if (equalActions) {
+          if (equals(actions[i], action)) {
             return true;
           }
         }

--- a/src/utils/__tests__/DispatchMockSpec.js
+++ b/src/utils/__tests__/DispatchMockSpec.js
@@ -83,15 +83,51 @@ describe('DispatchMock', () => {
 
     describe('when action has been dispatched', () => {
       describe('and all fields in action matches', () => {
-        it('returns true', () => {
-          const mock = createMockDispatch();
-          const action = {
-            type: 'type',
-            field1: 'field1',
-            field2: 'field2',
-          };
-          mock.dispatch(action);
-          expect(mock.isActionDispatched(action)).toBe(true);
+        describe('when all subFields matches', () => {
+          it('returns true', () => {
+            const mock = createMockDispatch();
+            const action = {
+              type: 'type',
+              field1: {
+                subField1: 'subField1',
+                subField2: 'subField2',
+              },
+              field2: 'field2',
+            };
+            const expectedAction = {
+              type: 'type',
+              field1: {
+                subField1: 'subField1',
+                subField2: 'subField2',
+              },
+              field2: 'field2',
+            };
+            mock.dispatch(action);
+            expect(mock.isActionDispatched(expectedAction)).toBe(true);
+          });
+        });
+
+        describe('when all subFields does not match', () => {
+          it('returns false', () => {
+            const mock = createMockDispatch();
+            const action = {
+              type: 'type',
+              field1: {
+                subField1: 'subField1',
+                subField2: 'subField2',
+              },
+              field2: 'field2',
+            };
+            const expectedAction = {
+              type: 'type',
+              field1: {
+                subField3: 'subField3',
+              },
+              field2: 'field2',
+            };
+            mock.dispatch(action);
+            expect(mock.isActionDispatched(expectedAction)).toBe(false);
+          });
         });
       });
 

--- a/src/utils/__tests__/equals.test.js
+++ b/src/utils/__tests__/equals.test.js
@@ -1,0 +1,124 @@
+import equals from '../equals';
+
+describe('equals', () => {
+  describe('one level', () => {
+    describe('when all keys are the same', () => {
+      it('returns true', () => {
+        const object1 = {
+          a: 'a',
+          b: 'b',
+        };
+        const object2 = {
+          a: 'a',
+          b: 'b',
+        };
+        expect(equals(object1, object2)).toBe(true);
+      });
+    });
+
+    describe('when all keys are the not same', () => {
+      it('returns false', () => {
+        const object1 = {
+          a: 'a',
+          b: 'b',
+        };
+        const object2 = {
+          a: 'a',
+          b: 'c',
+        };
+        expect(equals(object1, object2)).toBe(false);
+      });
+    });
+
+    describe('when not the same number of keys', () => {
+      it('returns false', () => {
+        const object1 = {
+          a: 'a',
+          b: 'b',
+          c: 'c',
+        };
+        const object2 = {
+          a: 'a',
+          b: 'b',
+        };
+        expect(equals(object1, object2)).toBe(false);
+      });
+    });
+  });
+
+  describe('two levels', () => {
+    describe('when all sub keys are the same', () => {
+      it('returns true', () => {
+        const object1 = {
+          a: {
+            b: 'b',
+          },
+        };
+        const object2 = {
+          a: {
+            b: 'b',
+          },
+        };
+        expect(equals(object1, object2)).toBe(true);
+      });
+    });
+  });
+
+  describe('when all sub keys are the not same', () => {
+    it('returns false', () => {
+      const object1 = {
+        a: {
+          b: 'b',
+        },
+      };
+      const object2 = {
+        a: {
+          c: 'c',
+        },
+      };
+      expect(equals(object1, object2)).toBe(false);
+    });
+  });
+
+  describe('three levels', () => {
+    describe('when all sub keys are the same', () => {
+      it('returns true', () => {
+        const object1 = {
+          a: {
+            b: {
+              c: 'c',
+            },
+          },
+        };
+        const object2 = {
+          a: {
+            b: {
+              c: 'c',
+            },
+          },
+        };
+        expect(equals(object1, object2)).toBe(true);
+      });
+    });
+  });
+
+  describe('when all sub keys are the not same', () => {
+    it('returns false', () => {
+      const object1 = {
+        a: {
+          b: {
+            c: 'c',
+          },
+        },
+      };
+      const object2 = {
+        a: {
+          b: {
+            d: 'd',
+          },
+        },
+      };
+      expect(equals(object1, object2)).toBe(false);
+    });
+  });
+});

--- a/src/utils/equals.js
+++ b/src/utils/equals.js
@@ -1,0 +1,11 @@
+const equals = (object1, object2) =>
+  (Object.keys(object1).length === Object.keys(object2).length
+    ? Object.keys(object1).reduce((e, key) => {
+      if (typeof object1[key] === 'object') {
+        return equals(object1[key], object2[key]);
+      }
+      return e && object1[key] === object2[key];
+    }, true)
+    : false);
+
+export default equals;


### PR DESCRIPTION
I didn't want to add lodash as a dependency so I created my own, really basic, implementation of equals for two objects. I don't know if there are more cases that should be handled.

Solves #1 .