### PR TITLE
Add support for thunks

### DIFF
--- a/src/utils/DispatchMock.js
+++ b/src/utils/DispatchMock.js
@@ -3,9 +3,17 @@ import deepEqual from 'fast-deep-equal';
 
 export const createMockDispatch = () => {
   const actions = [];
+  const logAction = (action) => {
+    actions.push(action);
+  };
+
   return {
     dispatch(action) {
-      actions.push(action);
+      if (action instanceof Function) {
+        action(logAction);
+      } else {
+        logAction(action);
+      }
     },
 
     getActions() {

--- a/src/utils/DispatchMock.js
+++ b/src/utils/DispatchMock.js
@@ -10,10 +10,10 @@ export const createMockDispatch = () => {
   return {
     dispatch(action) {
       if (action instanceof Function) {
-        action(logAction);
-      } else {
-        logAction(action);
+        return action(logAction);
       }
+
+      return logAction(action);
     },
 
     getActions() {

--- a/src/utils/__tests__/DispatchMockSpec.js
+++ b/src/utils/__tests__/DispatchMockSpec.js
@@ -45,6 +45,29 @@ describe('DispatchMock', () => {
         expect(mock.isActionTypeDispatched('action type')).toBe(true);
         expect(mock.isActionTypeDispatched('action type 2')).toBe(true);
       });
+
+      it('returns the result of the thunk from dispatch', (done) => {
+        const mock = createMockDispatch();
+        const action = (dispatch) => {
+          dispatch({ type: 'action type' });
+
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              dispatch({ type: 'action type 2' });
+              resolve('final return value');
+            }, 10);
+          });
+        };
+
+        mock.dispatch(action)
+          .then((res) => {
+            expect(mock.isActionTypeDispatched('action type')).toBe(true);
+            expect(mock.isActionTypeDispatched('action type 2')).toBe(true);
+            expect(res).toEqual('final return value');
+            done();
+          })
+          .catch(done);
+      });
     });
 
     describe('when several actions is dispatched', () => {

--- a/src/utils/__tests__/DispatchMockSpec.js
+++ b/src/utils/__tests__/DispatchMockSpec.js
@@ -33,6 +33,20 @@ describe('DispatchMock', () => {
       });
     });
 
+    describe('when an action creator returns a thunk', () => {
+      it('executes the thunk', () => {
+        const mock = createMockDispatch();
+        const action = (dispatch) => {
+          dispatch({ type: 'action type' });
+          dispatch({ type: 'action type 2' });
+        };
+
+        mock.dispatch(action);
+        expect(mock.isActionTypeDispatched('action type')).toBe(true);
+        expect(mock.isActionTypeDispatched('action type 2')).toBe(true);
+      });
+    });
+
     describe('when several actions is dispatched', () => {
       it('returns action with given type', () => {
         const mock = createMockDispatch();


### PR DESCRIPTION
This pull request changes the `dispatch` implementation so that if `action` is a function, it will execute it with a reference to the `dispatch` implementation. This makes it compatible with the thunk middleware and prevents the need to manually invoke functions that have been pushed into the `actions` array.